### PR TITLE
feat: add GitHub download type support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "dependencies": {
         "@bunli/core": "latest",
         "@holmlibs/unzip": "^1.0.0",
+        "@octokit/core": "^7.0.3",
         "@octokit/rest": "^22.0.0",
         "chalk": "^5.4.1",
         "chokidar": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 	"dependencies": {
 		"@bunli/core": "latest",
 		"@holmlibs/unzip": "^1.0.0",
+		"@octokit/core": "^7.0.3",
 		"@octokit/rest": "^22.0.0",
 		"chalk": "^5.4.1",
 		"chokidar": "^4.0.3",

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -2,6 +2,7 @@ import { defineCommand, option } from "@bunli/core";
 
 import AnalysisCoordinator from "core/analysis-coordinator";
 import { createNamespaceLogger } from "logging/logger-utilities";
+import GitHubDownloadType from "meta/github-download-type";
 import type RuntimeContext from "meta/runtime-context";
 import { relative } from "node:path";
 import {
@@ -147,7 +148,11 @@ export const analyzeCommand = defineCommand({
 
 			// Ensure prerequisites (globalTypes.d.luau)
 			commandSpinner.start(colors.blue("Checking prerequisites..."));
-			await coordinator.ensurePrerequisitesAsync(grab, verbose);
+			await coordinator.ensurePrerequisitesAsync(
+				configuration.fetchType ?? GitHubDownloadType.Fetch,
+				grab,
+				verbose,
+			);
 			commandSpinner.stop();
 
 			// Build ignore patterns

--- a/src/core/luau-lsp-runner.ts
+++ b/src/core/luau-lsp-runner.ts
@@ -146,33 +146,6 @@ export class LuauLspRunner {
 }
 
 /**
- * Downloads globalTypes.d.luau from the official repository.
- *
- * @param targetPath - Path to save the downloaded file (default:
- *   "globalTypes.d.luau").
- * @param verbose - Whether to have verbose logging for fetch.
- * @returns Promise resolving when download is complete.
- * @throws Error if download fails.
- */
-export async function downloadGlobalTypesAsync(targetPath = "globalTypes.d.luau", verbose = false): Promise<void> {
-	const url = "https://raw.githubusercontent.com/JohnnyMorganz/luau-lsp/main/scripts/globalTypes.d.luau";
-
-	try {
-		logger.info("Downloading globalTypes.d.luau...");
-		const response = await Bun.fetch(url, { verbose });
-
-		if (!response.ok) throw new Error(`Failed to download: ${response.status} ${response.statusText}`);
-
-		const content = await response.text();
-		await Bun.write(targetPath, content);
-		logger.info("Successfully downloaded globalTypes.d.luau");
-	} catch (error) {
-		logger.error(`Failed to download globalTypes.d.luau: ${error}`);
-		throw error;
-	}
-}
-
-/**
  * Generates a sourcemap using Rojo.
  *
  * @param projectFile - The path to the Rojo project file (e.g.,

--- a/src/functions/download-global-types-async.ts
+++ b/src/functions/download-global-types-async.ts
@@ -1,0 +1,97 @@
+import { Octokit } from "@octokit/core";
+
+import { createNamespaceLogger } from "logging/logger-utilities";
+import GitHubDownloadType from "meta/github-download-type";
+import { resolve } from "node:path";
+import { z } from "zod/mini";
+import { fromError } from "zod-validation-error";
+
+const logger = createNamespaceLogger("download-global-types-async");
+
+let coreCached: Octokit | undefined;
+function getOctokitCore(): Octokit {
+	if (coreCached) return coreCached;
+
+	const octokit = new Octokit({ auth: Bun.env.GITHUB_TOKEN });
+	coreCached = octokit;
+	return octokit;
+}
+
+async function fetchGlobalTypesAsync(targetPath: string, verbose: boolean): Promise<void> {
+	const url = "https://raw.githubusercontent.com/JohnnyMorganz/luau-lsp/main/scripts/globalTypes.d.luau";
+
+	try {
+		logger.info("Downloading globalTypes.d.luau using fetch...");
+		const response = await Bun.fetch(url, { verbose });
+
+		if (!response.ok) throw new Error(`Failed to download: ${response.status} ${response.statusText}`);
+
+		const content = await response.text();
+		await Bun.write(targetPath, content);
+		logger.info("Successfully downloaded globalTypes.d.luau");
+	} catch (error) {
+		logger.error(`Failed to download globalTypes.d.luau: ${error}`);
+		throw error;
+	}
+}
+
+const isGoodResponseData = z.object({
+	content: z.string(),
+	encoding: z.literal("base64"),
+});
+
+async function octokitGlobalTypesAsync(targetPath: string, verbose: boolean): Promise<void> {
+	try {
+		logger.info("Downloading globalTypes.d.luau using Octokit...");
+
+		const response = await getOctokitCore().request("GET /repos/{owner}/{repo}/contents/{path}", {
+			owner: "JohnnyMorganz",
+			path: "scripts/globalTypes.d.luau",
+			repo: "luau-lsp",
+		});
+
+		const result = await isGoodResponseData.safeParseAsync(response.data);
+		if (!result.success) throw fromError(result.error);
+
+		const content = Buffer.from(result.data.content, "base64").toString("utf-8");
+		const fullPath = resolve(process.cwd(), targetPath);
+
+		await Bun.write(fullPath, content);
+		if (verbose) logger.info(`Successfully downloaded globalTypes.d.luau to ${fullPath}`);
+	} catch (error: unknown) {
+		logger.error(`Failed to download globalTypes.d.luau using Octokit: ${error}`);
+		throw error;
+	}
+}
+
+/**
+ * Downloads globalTypes.d.luau from the official repository.
+ *
+ * @param githubDownloadType - The method to use for downloading.
+ * @param targetPath - Path to save the downloaded file (default:
+ *   "globalTypes.d.luau").
+ * @param verbose - Whether to have verbose logging for fetch.
+ * @returns Promise resolving when download is complete.
+ * @throws Error if download fails.
+ */
+export default async function downloadGlobalTypesAsync(
+	githubDownloadType: GitHubDownloadType = GitHubDownloadType.Fetch,
+	targetPath = "globalTypes.d.luau",
+	verbose = false,
+): Promise<void> {
+	switch (githubDownloadType) {
+		case GitHubDownloadType.Fetch: {
+			await fetchGlobalTypesAsync(targetPath, verbose);
+			break;
+		}
+
+		case GitHubDownloadType.OctokitCore: {
+			await octokitGlobalTypesAsync(targetPath, verbose);
+			break;
+		}
+
+		default: {
+			throw new Error(`Unknown download type: ${githubDownloadType}`);
+		}
+	}
+}

--- a/src/meta/github-download-type.ts
+++ b/src/meta/github-download-type.ts
@@ -1,0 +1,31 @@
+/**
+ * Enumerates the supported methods for downloading files from GitHub.
+ *
+ * This enum is used to specify which underlying implementation should be used
+ * when fetching files from GitHub repositories, allowing for flexibility and
+ * future extensibility.
+ *
+ * - `Fetch` uses the native fetch API for direct HTTP requests.
+ * - `OctokitCore` uses the Octokit Core library for authenticated or advanced
+ *   requests.
+ *
+ * @see https://docs.github.com/en/rest
+ */
+export const enum GitHubDownloadType {
+	/**
+	 * Use the native fetch API to download files from GitHub.
+	 *
+	 * This method is suitable for public repositories and simple HTTP requests.
+	 */
+	Fetch = "fetch",
+
+	/**
+	 * Use the Octokit Core library to download files from GitHub.
+	 *
+	 * This method supports authenticated requests and advanced GitHub API
+	 * features.
+	 */
+	OctokitCore = "octokit-core",
+}
+
+export default GitHubDownloadType;

--- a/src/utilities/configuration-utilities.ts
+++ b/src/utilities/configuration-utilities.ts
@@ -1,6 +1,7 @@
 import logger from "logging/logger";
 import type ConfigurationFileType from "meta/configuration-file-type";
 import ConfigurationFileTypeMeta, { type ConfigurationFileTypeMetadata } from "meta/configuration-file-type-meta";
+import GitHubDownloadType from "meta/github-download-type";
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { ContentType, fromPathLike, readFileAsync } from "utilities/file-system-utilities";
@@ -15,6 +16,19 @@ const PREFIX_DOT_REGEX = /^\./;
  * to your liking.
  */
 export const isPendantConfiguration = readonlyObject({
+	/**
+	 * The type of fetch to use for downloading files from GitHub. Defaults to
+	 * `fetch`.
+	 */
+	fetchType: z
+		.optional(
+			z._default(z.enum([GitHubDownloadType.Fetch, GitHubDownloadType.OctokitCore]), GitHubDownloadType.Fetch),
+		)
+		.register(z.globalRegistry, {
+			deprecated: false,
+			description: "The type of fetch to use for downloading files from GitHub. Defaults to `fetch`.",
+		}),
+
 	/**
 	 * How you configure the contexts for files. These are Roblox service class
 	 * names.

--- a/test/core/luau-lsp-runner.test.ts
+++ b/test/core/luau-lsp-runner.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import {
-	downloadGlobalTypesAsync,
 	generateSourcemapAsync,
 	type LuauLspAnalysisOptions,
 	LuauLspRunner,
 	type PrivateLuauLspRunner,
 } from "core/luau-lsp-runner";
+import downloadGlobalTypesAsync from "functions/download-global-types-async";
+import GitHubDownloadType from "meta/github-download-type";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -307,7 +308,7 @@ describe("luau-lsp-runner", () => {
 			const mockWrite = spyOn(Bun, "write").mockResolvedValue(100);
 
 			const targetPath = join(temporaryDirectory, GLOBAL_TYPES_FILE);
-			await downloadGlobalTypesAsync(targetPath);
+			await downloadGlobalTypesAsync(GitHubDownloadType.Fetch, targetPath);
 
 			expect(mockFetch).toHaveBeenCalledWith(
 				"https://raw.githubusercontent.com/JohnnyMorganz/luau-lsp/main/scripts/globalTypes.d.luau",
@@ -330,7 +331,9 @@ describe("luau-lsp-runner", () => {
 			const targetPath = join(temporaryDirectory, GLOBAL_TYPES_FILE);
 
 			// eslint-disable-next-line ts/await-thenable, ts/no-confusing-void-expression -- required
-			await expect(downloadGlobalTypesAsync(targetPath)).rejects.toThrow("Failed to download: 404 Not Found");
+			await expect(downloadGlobalTypesAsync(GitHubDownloadType.Fetch, targetPath)).rejects.toThrow(
+				"Failed to download: 404 Not Found",
+			);
 
 			mockFetch.mockRestore();
 		});
@@ -341,7 +344,9 @@ describe("luau-lsp-runner", () => {
 			const targetPath = join(temporaryDirectory, GLOBAL_TYPES_FILE);
 
 			// eslint-disable-next-line ts/await-thenable, ts/no-confusing-void-expression -- required
-			await expect(downloadGlobalTypesAsync(targetPath)).rejects.toThrow("Network error");
+			await expect(downloadGlobalTypesAsync(GitHubDownloadType.Fetch, targetPath)).rejects.toThrow(
+				"Network error",
+			);
 
 			mockFetch.mockRestore();
 		});


### PR DESCRIPTION
Introduced a new enum, GitHubDownloadType, to specify the method for
downloading files from GitHub. This allows for flexibility in using
either the native fetch API or the Octokit Core library for
authenticated requests. Updated relevant functions and tests to
accommodate this new functionality.

BREAKING CHANGE: The signature of downloadGlobalTypesAsync has
changed to include the new githubDownloadType parameter.